### PR TITLE
Add Great Expectations with AWS Glue Catalog Data Connector tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,32 @@ __pycache__/
 */.ipynb_checkpoints/*
 **/.DS_Store
 .idea/
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ to explore and demo Great Expectations. See the README in the directory for deta
 This example demonstrates the use of Great Expectations in a data pipeline with dbt and Apache Airflow. 
 See the README in the directory for details. **Note** This tutorial currently requires an update to work with the 
 new-style Checkpoints that were introduced in version 0.13.8.
+
+## gx_glue_catalog_tutorial
+This example contains a quickstart notebook and terraform code to setup required resources into your AWS account
+to show how [Great Expectations](https://greatexpectations.io) can be used together with [AWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/catalog-and-crawler.html) 
+to validate your data lake through tables organized into databases.

--- a/gx_glue_catalog_tutorial/README.md
+++ b/gx_glue_catalog_tutorial/README.md
@@ -1,0 +1,55 @@
+# Great Expectations with AWS Glue Data Catalog Tutorial
+
+The purpose of this example is to show how [Great Expectations](https://greatexpectations.io) can be used together with [AWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/catalog-and-crawler.html) to validate your data lake through tables organized into databases. This repository contains a notebook and terraform code to setup the required resources in your AWS account to use the new Great Expectations Glue Catalog Connector.
+
+## Project Structure
+```
+gx_glue_catalog_tutorial
+├── infra                                           # Terraform code
+│   └── ...
+├── notebooks
+│   └── GE-Demo-GlueCatalog-QuickStart.ipynb        # Quickstart notebook
+└── README.md
+```
+
+## Prerequisites
+
+To setup the environment required for this tutorial, make sure you have the following:
+1. An AWS account to deploy the required AWS resources.
+2. A machine with the following tools installed and configured:
+    1. [AWS Command Line Interface (AWS CLI)](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html).
+    2. [Terraform](https://www.terraform.io/).
+    3. [Git](https://git-scm.com/downloads).
+
+## Solution Deployment
+
+To deploy the required resources into your AWS account, follow these steps:
+1. In the command line, use the AWS CLI to setup the credentials to login into your AWS Account. Another option is to use environment variables, refer to the following as an example:
+    ```sh
+    export AWS_ACCESS_KEY_ID=***********
+    export AWS_SECRET_ACCESS_KEY=***********
+    export AWS_DEFAULT_REGION=us-east-1
+    ```
+
+2. Validate that you are authenticated by running the following code:
+    ```sh
+    aws sts get-caller-identity
+    ```
+    This command will output the UserId and Account you are authenticated.
+
+3. Once you validated your credentials, run the following to deploy the solution into your account:
+    ```sh
+    cd gx_glue_catalog_tutorial/infra
+    terraform init & terraform apply -auto-approve
+    ```
+4. Log in to the [AWS Console](https://aws.amazon.com/console/) using the same account used for the solution deployment, navigate to S3 and check the buckets. You shall have a bucket named **great-expectations-glue-demo-<AWS_ACCOUNT_ID>-<AWS_REGION>**.
+
+5. In the [AWS Console](https://aws.amazon.com/console/), navigate to Glue and, in Data Catalog, open databases. You shall have a database named **db_ge_with_glue_demo**. 
+
+6. Open the database and check its tables, you shall have a table named **tb_nyc_trip_data**. Open the table and check its partitions, you shall have three partitions, named: 2022-01, 2022-02, and 2022-03.
+
+7. In Glue console, open Jobs in AWS Glue Studio, select Jupyter Notebook and *Upload and edit an existing notebook*. Select Choose file, upload the [**GE-Demo-GlueCatalog-QuickStart.ipynb**](notebooks/GE-Demo-GlueCatalog-QuickStart.ipynb) that is in the notebook’s directory of the code repository and create the job.
+
+8. In the Notebook setup, enter a name of your choice and, in the IAM Role, select the role **GE-Glue-Demo-Role**. This role has been deployed for you as part of the solution deployment. Select Spark as the Kernel and start the notebook.
+
+Once you have completed all these steps, you shall have your environment ready to start working with Great Expectations and AWS Glue Data Catalog. Follow the instructions in the Glue Notebook you have created.

--- a/gx_glue_catalog_tutorial/infra/aws_data.tf
+++ b/gx_glue_catalog_tutorial/infra/aws_data.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+data "aws_iam_policy" "AWSGlueServiceRole" {
+  name = "AWSGlueServiceRole"
+}

--- a/gx_glue_catalog_tutorial/infra/main.tf
+++ b/gx_glue_catalog_tutorial/infra/main.tf
@@ -1,0 +1,353 @@
+locals {
+  bucket_name    = "${var.bucket_name}-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
+  table_location = "${var.datalake_prefix}/${var.database_name}/${var.table_name}"
+}
+
+###################
+## S3 Buckets    ##
+###################
+resource "aws_s3_bucket" "this" {
+  bucket        = local.bucket_name
+  force_destroy = true
+
+  tags = var.tags
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+
+    bucket_key_enabled = true
+  }
+
+  depends_on = [
+    aws_s3_bucket.this
+  ]
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  depends_on = [
+    aws_s3_bucket.this
+  ]
+}
+
+# Upload data to s3 bucket
+resource "aws_s3_object_copy" "this" {
+  for_each = toset(var.batch_dates)
+
+  bucket = aws_s3_bucket.this.id
+  key    = "${local.table_location}/year=${split("-", each.value)[0]}/month=${split("-", each.value)[1]}/yellow_tripdata_${each.value}.parquet"
+  source = "nyc-tlc/trip data/yellow_tripdata_${each.value}.parquet"
+
+  depends_on = [
+    aws_s3_bucket.this
+  ]
+}
+
+###################
+## IAM Roles     ##
+###################
+resource "aws_iam_policy" "this" {
+  name        = "${var.glue_role_name}-Policy"
+  path        = "/"
+  description = "Great Expectations with AWS Glue Data Catalog Demo Role Policy"
+  tags        = var.tags
+
+  # Terraform"s "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement : [
+      {
+        "Sid" : "GrantS3Permissions",
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:*",
+        ],
+        "Resource" : [
+          "${aws_s3_bucket.this.arn}/*",
+          aws_s3_bucket.this.arn
+        ]
+      },
+      {
+        "Sid" : "GrantGlueNotebookAccess",
+        "Effect" : "Allow",
+        "Action" : "iam:PassRole",
+        "Resource" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.glue_role_name}"
+      }
+    ]
+  })
+
+  depends_on = [
+    aws_s3_bucket.this
+  ]
+}
+
+resource "aws_iam_role" "this" {
+  name                = var.glue_role_name
+  managed_policy_arns = [data.aws_iam_policy.AWSGlueServiceRole.arn, aws_iam_policy.this.arn]
+  tags                = var.tags
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = [
+            "glue.amazonaws.com"
+          ]
+        }
+      }
+    ]
+  })
+
+  depends_on = [aws_iam_policy.this]
+}
+
+
+###################
+## Glue Catalog  ##
+###################
+
+resource "aws_glue_catalog_database" "this" {
+  name = var.database_name
+
+  create_table_default_permission {
+    permissions = ["ALL"]
+
+    principal {
+      data_lake_principal_identifier = "IAM_ALLOWED_PRINCIPALS"
+    }
+  }
+}
+
+resource "aws_glue_catalog_table" "this" {
+  name          = var.table_name
+  database_name = aws_glue_catalog_database.this.name
+  description   = "Table for NYC Trip Data"
+
+  table_type = "EXTERNAL_TABLE"
+
+  parameters = {
+    "EXTERNAL"       = "TRUE"
+    "classification" = "parquet"
+  }
+
+  partition_keys {
+    name = "year"
+    type = "string"
+  }
+  partition_keys {
+    name = "month"
+    type = "string"
+  }
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.this.id}/${local.table_location}/"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+    compressed    = false
+
+    ser_de_info {
+      name                  = "ParquetHiveSerDe"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+
+      parameters = {
+        "serialization.format" = "1"
+      }
+    }
+
+    columns {
+      name = "vendorid"
+      type = "bigint"
+    }
+    columns {
+      name = "tpep_pickup_datetime"
+      type = "timestamp"
+    }
+    columns {
+      name = "tpep_dropoff_datetime"
+      type = "timestamp"
+    }
+    columns {
+      name = "passenger_count"
+      type = "double"
+    }
+    columns {
+      name = "trip_distance"
+      type = "double"
+    }
+    columns {
+      name = "ratecodeid"
+      type = "double"
+    }
+    columns {
+      name = "store_and_fwd_flag"
+      type = "string"
+    }
+    columns {
+      name = "pulocationid"
+      type = "bigint"
+    }
+    columns {
+      name = "dolocationid"
+      type = "bigint"
+    }
+    columns {
+      name = "payment_type"
+      type = "bigint"
+    }
+    columns {
+      name = "fare_amount"
+      type = "double"
+    }
+    columns {
+      name = "extra"
+      type = "double"
+    }
+    columns {
+      name = "mta_tax"
+      type = "double"
+    }
+    columns {
+      name = "tip_amount"
+      type = "double"
+    }
+    columns {
+      name = "tolls_amount"
+      type = "double"
+    }
+    columns {
+      name = "improvement_surcharge"
+      type = "double"
+    }
+    columns {
+      name = "total_amount"
+      type = "double"
+    }
+    columns {
+      name = "congestion_surcharge"
+      type = "double"
+    }
+    columns {
+      name = "airport_fee"
+      type = "double"
+    }
+  }
+}
+
+resource "aws_glue_partition" "this" {
+  for_each = toset(var.batch_dates)
+
+  database_name    = aws_glue_catalog_database.this.name
+  table_name       = aws_glue_catalog_table.this.name
+  partition_values = [split("-", each.value)[0], split("-", each.value)[1]]
+
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.this.id}/${local.table_location}/year=${split("-", each.value)[0]}/month=${split("-", each.value)[1]}/"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+    compressed    = false
+
+    ser_de_info {
+      name                  = "ParquetHiveSerDe"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+
+      parameters = {
+        "serialization.format" = "1"
+      }
+    }
+
+    columns {
+      name = "vendorid"
+      type = "bigint"
+    }
+    columns {
+      name = "tpep_pickup_datetime"
+      type = "timestamp"
+    }
+    columns {
+      name = "tpep_dropoff_datetime"
+      type = "timestamp"
+    }
+    columns {
+      name = "passenger_count"
+      type = "double"
+    }
+    columns {
+      name = "trip_distance"
+      type = "double"
+    }
+    columns {
+      name = "ratecodeid"
+      type = "double"
+    }
+    columns {
+      name = "store_and_fwd_flag"
+      type = "string"
+    }
+    columns {
+      name = "pulocationid"
+      type = "bigint"
+    }
+    columns {
+      name = "dolocationid"
+      type = "bigint"
+    }
+    columns {
+      name = "payment_type"
+      type = "bigint"
+    }
+    columns {
+      name = "fare_amount"
+      type = "double"
+    }
+    columns {
+      name = "extra"
+      type = "double"
+    }
+    columns {
+      name = "mta_tax"
+      type = "double"
+    }
+    columns {
+      name = "tip_amount"
+      type = "double"
+    }
+    columns {
+      name = "tolls_amount"
+      type = "double"
+    }
+    columns {
+      name = "improvement_surcharge"
+      type = "double"
+    }
+    columns {
+      name = "total_amount"
+      type = "double"
+    }
+    columns {
+      name = "congestion_surcharge"
+      type = "double"
+    }
+    columns {
+      name = "airport_fee"
+      type = "double"
+    }
+  }
+}

--- a/gx_glue_catalog_tutorial/infra/outputs.tf
+++ b/gx_glue_catalog_tutorial/infra/outputs.tf
@@ -1,0 +1,15 @@
+output "bucketName" {
+  value = aws_s3_bucket.this.id
+}
+
+output "glueRoleArn" {
+  value = aws_iam_role.this.arn
+}
+
+output "databaseName" {
+  value = aws_glue_catalog_database.this.id
+}
+
+output "tableName" {
+  value = aws_glue_catalog_table.this.id
+}

--- a/gx_glue_catalog_tutorial/infra/variables.tf
+++ b/gx_glue_catalog_tutorial/infra/variables.tf
@@ -1,0 +1,46 @@
+
+variable "bucket_name" {
+    type = string
+    description = "The bucket name to store data lake files"
+    default = "great-expectations-glue-demo"
+}
+
+variable "datalake_prefix" {
+    type = string
+    description = "The prefix to store data lake data"
+    default = "datalake"
+}
+
+
+variable "batch_dates" {
+    type = list(string)
+    description = "The Year-Month to load files from NYC Trip Data into the bucket"
+    default = ["2022-01", "2022-02", "2022-03"]
+}
+
+variable "database_name" {
+    type = string
+    description = "The database name to create in Glue Data Catalog"
+    default = "db_ge_with_glue_demo"
+}
+
+variable "table_name" {
+    type = string
+    description = "The table name for the NYC Trip Data"
+    default = "tb_nyc_trip_data"
+}
+
+variable "glue_role_name" {
+    type = string
+    description = "The glue role name"
+    default = "GE-Glue-Demo-Role"
+}
+
+variable "tags"{
+    type = map(string)
+    description = "Tags to be applied in the resources created."
+    default = {
+        ProjectName = "Great Expectations with Glue Data Catalog Demo"
+        CreatedBy = "Terraform"
+    }
+}

--- a/gx_glue_catalog_tutorial/notebooks/GE-Demo-GlueCatalog-QuickStart.ipynb
+++ b/gx_glue_catalog_tutorial/notebooks/GE-Demo-GlueCatalog-QuickStart.ipynb
@@ -1,0 +1,327 @@
+{
+	"cells": [
+		{
+			"cell_type": "markdown",
+			"metadata": {
+				"deletable": false,
+				"editable": false,
+				"trusted": true
+			},
+			"source": [
+				"\n",
+				"# How to use Great Expectations with AWS Glue Data Catalog\n",
+				"\n",
+				"In this notebook, we will walk through the steps-by-steps to setup Great Expectations with AWS Glue Data Catalog. Before you can start running this notebook, you must start an interactive session."
+			]
+		},
+		{
+			"cell_type": "markdown",
+			"metadata": {},
+			"source": [
+				"## 0. Setup AWS Glue Interactive Session\n",
+				"\n",
+				"Before starting coding, be aware that there are a few options to set up an AWS Glue interactive session. In the following code cell, we are using some of them. Refer to the [AWS glue interactive session documentation](https://docs.aws.amazon.com/glue/latest/dg/interactive-sessions-magics.html) for a complete view of the options available. \n",
+				"\n",
+				"Run the next code cell to setup the interactive session:"
+			]
+		},
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {
+				"trusted": true
+			},
+			"outputs": [],
+			"source": [
+				"%additional_python_modules great_expectations\n",
+				"%glue_version 3.0\n",
+				"%number_of_workers 2"
+			]
+		},
+		{
+			"cell_type": "markdown",
+			"metadata": {},
+			"source": [
+				"Once you run the cell, the interactive session will be configured to use Glue 3.0, allocate 2 DPUs and install the Great Expectations package. Feel free to add or modify this setup as you like. The interactive session will not be created until we execute some code. Let’s start the session by running the following code cell to import some standard Glue libraries:"
+			]
+		},
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {
+				"editable": true,
+				"trusted": true
+			},
+			"outputs": [],
+			"source": [
+				"import sys\n",
+				"from awsglue.transforms import *\n",
+				"from awsglue.utils import getResolvedOptions\n",
+				"from pyspark.context import SparkContext\n",
+				"from awsglue.context import GlueContext\n",
+				"from awsglue.job import Job\n",
+				"\n",
+				"sc = SparkContext.getOrCreate()\n",
+				"glueContext = GlueContext(sc)\n",
+				"spark = glueContext.spark_session\n",
+				"job = Job(glueContext)\n"
+			]
+		},
+		{
+			"cell_type": "markdown",
+			"metadata": {},
+			"source": [
+				"## 1. Create a Data Context\n",
+				"\n",
+				"For the sake of simplicity, we will create the Great Expectations Data Context in-memory using an Amazon S3 bucket as the store backend. The following example shows a Data Context configuration with a Spark datasource using the new AWS Glue Catalog Data Connector. Refer to the [following documentation](https://docs.greatexpectations.io/docs/guides/setup/configuring_data_contexts/how_to_instantiate_a_data_context_without_a_yml_file#2-pass-this-datacontextconfig-as-a-project_config-to-basedatacontext) for a better understanding.\n",
+				"\n",
+				"Run the following cell to create the Data Context:\n"
+			]
+		},
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {
+				"trusted": true
+			},
+			"outputs": [],
+			"source": [
+				"from great_expectations.data_context.types.base import DataContextConfig, DatasourceConfig, S3StoreBackendDefaults\n",
+				"from great_expectations.data_context import BaseDataContext\n",
+				"\n",
+				"data_connectors = {\n",
+				"    \"Runtime\": {\n",
+				"        \"class_name\": \"RuntimeDataConnector\",\n",
+				"        \"batch_identifiers\": [\"batch_id\"]\n",
+				"    },\n",
+				"    \"InferredGlue\": {\n",
+				"        \"class_name\": \"InferredAssetAWSGlueDataCatalogDataConnector\"\n",
+				"    },\n",
+				"    \"ConfiguredGlue\": {\n",
+				"        \"class_name\": \"ConfiguredAssetAWSGlueDataCatalogDataConnector\",\n",
+				"        \"assets\": {\n",
+				"            \"nyc_trip_data_asset\": {\n",
+				"                \"table_name\": \"tb_nyc_trip_data\",\n",
+				"                \"database_name\": \"db_ge_with_glue_demo\"\n",
+				"            }\n",
+				"        }\n",
+				"    }\n",
+				"}\n",
+				"\n",
+				"glue_data_source = DatasourceConfig(\n",
+				"    class_name=\"Datasource\",\n",
+				"    execution_engine={\n",
+				"        \"class_name\": \"SparkDFExecutionEngine\",\n",
+				"        \"force_reuse_spark_context\": True,\n",
+				"    },\n",
+				"    data_connectors=data_connectors\n",
+				")\n",
+				"\n",
+				"metastore_backed = S3StoreBackendDefaults(default_bucket_name=\"great-expectations-glue-demo-<AWS_ACCOUNT_ID>-us-east-1\")\n",
+				"\n",
+				"data_context_config = DataContextConfig(\n",
+				"    datasources={\"GlueDataSource\": glue_data_source},\n",
+				"    store_backend_defaults=metastore_backed,\n",
+				")\n",
+				"\n",
+				"context = BaseDataContext(project_config=data_context_config)"
+			]
+		},
+		{
+			"cell_type": "markdown",
+			"metadata": {},
+			"source": [
+				"Now that we have a DataContext, we can check for the available data assets that the AWS Glue Data Connector was able to get from the Glue Catalog. Run the following code to get a list of available data assets:"
+			]
+		},
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {
+				"trusted": true
+			},
+			"outputs": [],
+			"source": [
+				"from pprint import pprint\n",
+				"\n",
+				"pprint(context.get_available_data_asset_names())"
+			]
+		},
+		{
+			"cell_type": "markdown",
+			"metadata": {},
+			"source": [
+				"If you have deployed the provided terraform code into you AWS account, you shall see that the InferredGlue connector returned the table *db_ge_with_glue_demo.tb_nyc_trip_data*. This table was created as part of the solution deployment. If you have more tables in the Glue Catalog, this connector shall output all of them. \n",
+				"\n",
+				"For a fine-grained control of what tables shall be available, use the **ConfiguredGlue** as an example. The Configured Connector requires that you define each database table you would like to validate. Be aware that the connector will not validate if, for any of the tables you define, the table exists nor if you have permissions to access it. Note: If you’re using AWS Lake Formation, check if the Glue IAM role has permissions to access it."
+			]
+		},
+		{
+			"cell_type": "markdown",
+			"metadata": {},
+			"source": [
+				"## 2. Create Expectations\n",
+				"\n",
+				"Once you have the data context already setup, you can start to create the Expectations for our tables. Run the following code cell to create an Expectation Suite and a validator that we can use to create the expectations interactively. "
+			]
+		},
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {
+				"trusted": true
+			},
+			"outputs": [],
+			"source": [
+				"from great_expectations.core.batch import BatchRequest\n",
+				"\n",
+				"expectation_suite_name = \"demo.taxi_trip.warning\"\n",
+				"\n",
+				"# Create Expectation Suite\n",
+				"suite = context.create_expectation_suite(\n",
+				"    expectation_suite_name=expectation_suite_name,\n",
+				"    overwrite_existing=True,\n",
+				")\n",
+				"\n",
+				"# Batch Request\n",
+				"batch_request = BatchRequest(\n",
+				"    datasource_name=\"GlueDataSource\",\n",
+				"    data_connector_name=\"InferredGlue\",\n",
+				"    data_asset_name=\"db_ge_with_glue_demo.tb_nyc_trip_data\",\n",
+				"    data_connector_query={\n",
+				"        \"batch_filter_parameters\": {\n",
+				"            \"year\": \"2022\", \n",
+				"            \"month\": \"03\"\n",
+				"        }\n",
+				"    }\n",
+				")\n",
+				"\n",
+				"# Validator\n",
+				"validator = context.get_validator(\n",
+				"    batch_request=batch_request,\n",
+				"    expectation_suite_name=expectation_suite_name,\n",
+				")\n",
+				"\n",
+				"# Print\n",
+				"df = validator.head(n_rows=5, fetch_all=False)\n",
+				"pprint(df.info())"
+			]
+		},
+		{
+			"cell_type": "markdown",
+			"metadata": {},
+			"source": [
+				"Be aware that, the table we are using in this demo, is partitioned by year and month. Check the Table in Glue Data Catalog and you shall see that there are three partitions, named: 2022-01, 2022-02, 2022-03. For each table partition, the connector will create a batch identifier that allows us to filter a batch of data based on the partition values. In the code above, we are loading the partition 2022-03. If you do not specify the partition, the connector will get the first partition available by default. Note: filtering a partition is only available if your table is partitioned, otherwise, the table data will be loaded in a single batch.\n",
+				"\n",
+				"After running the code cell above, you can start to define the Expectations you want. Use the following code as example on how to define the Expectations and save it:\n"
+			]
+		},
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {
+				"trusted": true
+			},
+			"outputs": [],
+			"source": [
+				"# Define the Expectations\n",
+				"validator.expect_table_row_count_to_be_between(min_value=1, max_value=None)\n",
+				"validator.expect_column_values_to_not_be_null(column=\"vendorid\")\n",
+				"validator.expect_column_values_to_be_between(column=\"passenger_count\", min_value=0, max_value=9)\n",
+				"\n",
+				"# Save the Expectation Suite\n",
+				"validator.save_expectation_suite(discard_failed_expectations=False)"
+			]
+		},
+		{
+			"cell_type": "markdown",
+			"metadata": {},
+			"source": [
+				"Validate that the Expectation Suite was saved into the S3 Bucket we have defined as our store backend. "
+			]
+		},
+		{
+			"cell_type": "markdown",
+			"metadata": {},
+			"source": [
+				"## 3. Validate Data\n",
+				"\n",
+				"With the Expectation Suite already created, we can create a Checkpoint to validate data. Run the following code cell to create, save, and run the Checkpoint to get the validation results:"
+			]
+		},
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {
+				"trusted": true
+			},
+			"outputs": [],
+			"source": [
+				"from ruamel import yaml\n",
+				"\n",
+				"# Create Checkpoint\n",
+				"my_checkpoint_name = \"demo.taxi_trip.checkpoint\" \n",
+				"\n",
+				"yaml_config = f\"\"\"\n",
+				"name: {my_checkpoint_name}\n",
+				"config_version: 1.0\n",
+				"module_name: great_expectations.checkpoint\n",
+				"class_name: Checkpoint\n",
+				"run_name_template: \"%Y%m%d-TaxiTrip-GlueInferred\"\n",
+				"action_list:\n",
+				"  - name: store_validation_result\n",
+				"    action:\n",
+				"      class_name: StoreValidationResultAction\n",
+				"  - name: update_data_docs\n",
+				"    action:\n",
+				"      class_name: UpdateDataDocsAction\n",
+				"      site_names: []\n",
+				"validations:\n",
+				"  - batch_request:\n",
+				"      datasource_name: GlueDataSource\n",
+				"      data_connector_name: InferredGlue\n",
+				"      data_asset_name: db_ge_with_glue_demo.tb_nyc_trip_data\n",
+				"      data_connector_query:\n",
+				"        batch_filter_parameters:\n",
+				"          year: '2022'\n",
+				"          month: '03'\n",
+				"    expectation_suite_name: {expectation_suite_name}\n",
+				"\"\"\"\n",
+				"\n",
+				"# Save Checkpoint\n",
+				"_ = context.add_checkpoint(**yaml.load(yaml_config))\n",
+				"\n",
+				"# Run Checkpoint\n",
+				"r = context.run_checkpoint(checkpoint_name=my_checkpoint_name)\n",
+				"pprint(r)"
+			]
+		},
+		{
+			"cell_type": "markdown",
+			"metadata": {},
+			"source": [
+				"🚀🚀 Congratulations! 🚀🚀 You’ve successfully connected Great Expectations with your data through AWS Glue Data Catalog."
+			]
+		}
+	],
+	"metadata": {
+		"kernelspec": {
+			"display_name": "Glue PySpark",
+			"language": "python",
+			"name": "glue_pyspark"
+		},
+		"language_info": {
+			"codemirror_mode": {
+				"name": "python",
+				"version": 3
+			},
+			"file_extension": ".py",
+			"mimetype": "text/x-python",
+			"name": "python",
+			"pygments_lexer": "python3",
+			"version": "3.9.7"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 4
+}


### PR DESCRIPTION
In this PR, I am providing a quickstart notebook with some terraform code to setup minimum resources in an AWS account to show how to use the Great Expectations to validate data through AWS Glue Data Catalog.